### PR TITLE
Allow NULL return for modeled variables stored in Postgres

### DIFF
--- a/Sources/PerfectPostgreSQL.swift
+++ b/Sources/PerfectPostgreSQL.swift
@@ -150,7 +150,7 @@ public final class PGResult {
 	
     /// return value for Int field type with row and field indexes provided
 	public func getFieldInt(tupleIndex: Int, fieldIndex: Int) -> Int? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int(s)
@@ -158,7 +158,7 @@ public final class PGResult {
 	
     /// return value for Bool field type with row and field indexes provided
 	public func getFieldBool(tupleIndex: Int, fieldIndex: Int) -> Bool? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return s == "t"
@@ -166,7 +166,7 @@ public final class PGResult {
 	
     /// return value for Int8 field type with row and field indexes provided
 	public func getFieldInt8(tupleIndex: Int, fieldIndex: Int) -> Int8? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int8(s)
@@ -174,7 +174,7 @@ public final class PGResult {
 	
     /// return value for Int16 field type with row and field indexes provided
 	public func getFieldInt16(tupleIndex: Int, fieldIndex: Int) -> Int16? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int16(s)
@@ -182,7 +182,7 @@ public final class PGResult {
 	
     /// return value for Int32 field type with row and field indexes provided
 	public func getFieldInt32(tupleIndex: Int, fieldIndex: Int) -> Int32? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int32(s)
@@ -190,7 +190,7 @@ public final class PGResult {
 	
     /// return value for Int64 field type with row and field indexes provided
 	public func getFieldInt64(tupleIndex: Int, fieldIndex: Int) -> Int64? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int64(s)
@@ -198,7 +198,7 @@ public final class PGResult {
 	
     /// return value for Double field type with row and field indexes provided
 	public func getFieldDouble(tupleIndex: Int, fieldIndex: Int) -> Double? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Double(s)
@@ -206,7 +206,7 @@ public final class PGResult {
 	
     /// return value for Float field type with row and field indexes provided
 	public func getFieldFloat(tupleIndex: Int, fieldIndex: Int) -> Float? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Float(s)
@@ -214,7 +214,7 @@ public final class PGResult {
 	
     /// return value for Blob field type with row and field indexes provided
 	public func getFieldBlob(tupleIndex: Int, fieldIndex: Int) -> [Int8]? {
-		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		let sc = s.utf8

--- a/Sources/PerfectPostgreSQL.swift
+++ b/Sources/PerfectPostgreSQL.swift
@@ -142,7 +142,7 @@ public final class PGResult {
 	
     /// return value for String field type with row and field indexes provided
 	public func getFieldString(tupleIndex: Int, fieldIndex: Int) -> String? {
-		guard let v = PQgetvalue(self.res, Int32(tupleIndex), Int32(fieldIndex)) else {
+		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let v = PQgetvalue(self.res, Int32(tupleIndex), Int32(fieldIndex)) else {
 			return nil
 		}
 		return String(validatingUTF8: v)
@@ -150,7 +150,7 @@ public final class PGResult {
 	
     /// return value for Int field type with row and field indexes provided
 	public func getFieldInt(tupleIndex: Int, fieldIndex: Int) -> Int? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int(s)
@@ -158,7 +158,7 @@ public final class PGResult {
 	
     /// return value for Bool field type with row and field indexes provided
 	public func getFieldBool(tupleIndex: Int, fieldIndex: Int) -> Bool? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return s == "t"
@@ -166,7 +166,7 @@ public final class PGResult {
 	
     /// return value for Int8 field type with row and field indexes provided
 	public func getFieldInt8(tupleIndex: Int, fieldIndex: Int) -> Int8? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int8(s)
@@ -174,7 +174,7 @@ public final class PGResult {
 	
     /// return value for Int16 field type with row and field indexes provided
 	public func getFieldInt16(tupleIndex: Int, fieldIndex: Int) -> Int16? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int16(s)
@@ -182,7 +182,7 @@ public final class PGResult {
 	
     /// return value for Int32 field type with row and field indexes provided
 	public func getFieldInt32(tupleIndex: Int, fieldIndex: Int) -> Int32? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int32(s)
@@ -190,7 +190,7 @@ public final class PGResult {
 	
     /// return value for Int64 field type with row and field indexes provided
 	public func getFieldInt64(tupleIndex: Int, fieldIndex: Int) -> Int64? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Int64(s)
@@ -198,7 +198,7 @@ public final class PGResult {
 	
     /// return value for Double field type with row and field indexes provided
 	public func getFieldDouble(tupleIndex: Int, fieldIndex: Int) -> Double? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Double(s)
@@ -206,7 +206,7 @@ public final class PGResult {
 	
     /// return value for Float field type with row and field indexes provided
 	public func getFieldFloat(tupleIndex: Int, fieldIndex: Int) -> Float? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		return Float(s)
@@ -214,7 +214,7 @@ public final class PGResult {
 	
     /// return value for Blob field type with row and field indexes provided
 	public func getFieldBlob(tupleIndex: Int, fieldIndex: Int) -> [Int8]? {
-		guard !fieldIsNull(tupleIndex: tupleIndex, fieldIndex: fieldIndex), let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
+		guard let s = getFieldString(tupleIndex: tupleIndex, fieldIndex: fieldIndex) else {
 			return nil
 		}
 		let sc = s.utf8


### PR DESCRIPTION
This PR is in preparation for another PR for StORM.

I did see a PR for this same functionality back in April, but it looks like it will give some conflicts.

The idea of this PR is not just to fix PerfectPostgresSQL return of an actual null value in the database to correctly reflect in your model, but is also intended for the following updates to StORM & PostgresStORM:

This will support the following updates to StORM:
- Embedded mirroring through all the necessary superclasses to pull out the labels/values like StORM implementing through the one level deep mirroring.  This includes easier identification of primary keys and subclassing support.
- Support for optional declared variables.

This will support the following updates to PostgresStORM:
- Adds support for subclassing PostgresStORM models.
- Adds support for optional variables for updating, inserting, creating & setup of database tables.
- Adds support to automatically create an incrementing sequence for integer primary keys.
- Adds support for automatic created/modified fields to update on create/save functions.
- Adds support for automatic created by/modifiedby user_id strings by using a new save function specifying the auditUserId.

I will plan on giving examples in the README so if PerfectlySoft decides to use these updates, they can take the examples & update the main website that contains most of the documentation.  

Let me know if this would affect the future roadmaps for these frameworks - I would not mind making it comply for any future updates.