### PR TITLE
Added functions for sending COPY data

### DIFF
--- a/Sources/PerfectPostgreSQL.swift
+++ b/Sources/PerfectPostgreSQL.swift
@@ -328,7 +328,20 @@ public final class PGConnection {
 	public func exec(statement: String) -> PGResult {
 		return PGResult(PQexec(self.conn, statement))
 	}
-	
+
+    /// Sends data to the server during COPY_IN state.
+    public func putCopyData(data: String) {
+        PQputCopyData(self.conn, data, Int32(data.count))
+    }
+
+    /// Sends end-of-data indication to the server during COPY_IN state.
+    /// If withError is set, the copy is forced to fail with the error description supplied.
+    public func putCopyEnd(withError: String? = nil) -> PGResult {
+        PQputCopyEnd(self.conn, withError)
+        let result = PGResult(PQgetResult(self.conn))
+        return result
+    }
+
 	// !FIX! does not handle binary data
     /// Submits a command to the server and waits for the result, with the ability to pass parameters separately from the SQL command text.
 	public func exec(statement: String, params: [Any?]) -> PGResult {


### PR DESCRIPTION
Added copy functions for sending COPY data. These are described here:

https://www.postgresql.org/docs/9.4/static/libpq-copy.html

These functions are fantastic for seeding or importing mass data and could not be exposed via an extension due to the fact that `conn` is internal only.