### PR TITLE
Fix overflow during fetching blob field

### DIFF
--- a/Sources/PerfectPostgreSQL/PerfectPostgreSQL.swift
+++ b/Sources/PerfectPostgreSQL/PerfectPostgreSQL.swift
@@ -270,7 +270,7 @@ public final class PGResult {
 			return nil
 		}
 		
-		newChar *= 16
+		newChar = newChar &* 16
 		
 		if c2v >= capA && c2v <= capF {
 			newChar += c2v - capA + 10


### PR DESCRIPTION
<img width="1163" alt="screen shot 2018-06-23 at 1 34 15 pm" src="https://user-images.githubusercontent.com/22194043/41808137-39c0498a-76ea-11e8-8a99-20d3991aa08d.png">
Module crashes every time during fetching blob field. Any 'newChar' greater than 7 will cause a crash. 