### PR TITLE
Modified PostgresExeDelegate.hasNext() to throw an exception rather than returning empty-iterator

### DIFF
--- a/Sources/PerfectPostgreSQL/PerfectPostgreSQL.swift
+++ b/Sources/PerfectPostgreSQL/PerfectPostgreSQL.swift
@@ -41,8 +41,8 @@ public final class PGResult {
 		case unknown
 	}
 	
-	var res: OpaquePointer? = OpaquePointer(bitPattern: 0)
-	var borrowed = false
+	private var res: OpaquePointer? = OpaquePointer(bitPattern: 0)
+	private var borrowed = false
 	
 	init(_ res: OpaquePointer?, isBorrowed: Bool = false) {
 		self.res = res
@@ -53,6 +53,10 @@ public final class PGResult {
 		close()
 	}
 	
+	func isValid() -> Bool {
+		return res != nil
+	}
+
 	/// close result object
 	public func close() {
 		clear()

--- a/Sources/PerfectPostgreSQL/PostgresCRUD.swift
+++ b/Sources/PerfectPostgreSQL/PostgresCRUD.swift
@@ -381,6 +381,14 @@ class PostgresExeDelegate: SQLExeDelegate {
 										params: nextBindings.map {
 											try bindOne(expr: $0.1) })
 			results = r
+			guard r.isValid() else {
+				switch connection.status() {
+				case .ok:
+					throw CRUDSQLExeError("Fatal error on SQL execution")
+				case .bad:
+					throw CRUDSQLExeError(connection.errorMessage())
+				}
+			}
 			let status = r.status()
 			switch status {
 			case .emptyQuery:
@@ -514,4 +522,3 @@ public struct PostgresDatabaseConfiguration: DatabaseConfigurationProtocol {
 		return PostgresExeDelegate(connection: connection, sql: forSQL)
 	}
 }
-


### PR DESCRIPTION
PostgresExeDelegate.hasNext() returned false if a connection error occured. I guess it should throw an exception to identify a connection error and empty-result.

The logic returning false on connection errors is below:
* PQexec/PQexecParams returns NULL on connection errors.
* PGConnection.exec returns PGResult which .res == nil.
* PGResult.status() returns .unknown.
* PostgresExeDelegate.hasNext() returns false.

So I modified PostgresExeDelegate.hasNext() to check PGResult.res is nil or not.